### PR TITLE
MSAA compatibility

### DIFF
--- a/NewCloudsGD.tres
+++ b/NewCloudsGD.tres
@@ -7,7 +7,7 @@
 [ext_resource type="Texture2D" uid="uid://g02m2ewpwusq" path="res://addons/SunshineClouds2/NoiseTextures/HeightGradient.tres" id="5_mrg3l"]
 [ext_resource type="NoiseTexture3D" uid="uid://6ed3lvlpbqmg" path="res://addons/SunshineClouds2/NoiseTextures/LargeScaleNoise.tres" id="6_iyxim"]
 [ext_resource type="NoiseTexture3D" uid="uid://dxyewgt7o40m0" path="res://addons/SunshineClouds2/NoiseTextures/MediumScaleNoise.tres" id="7_opodv"]
-[ext_resource type="RDShaderFile" uid="uid://chxheyp4eohbc" path="res://addons/SunshineClouds2/SunshineCloudsPostCompute.glsl" id="8_f8qfs"]
+[ext_resource type="RDShaderFile" uid="uid://cqhejbalsrvjp" path="res://addons/SunshineClouds2/SunshineCloudsPostCompute.glsl" id="8_lebqt"]
 [ext_resource type="RDShaderFile" uid="uid://crfpk8ta4qxsk" path="res://addons/SunshineClouds2/SunshineCloudsPreCompute.glsl" id="9_bt1pb"]
 [ext_resource type="Script" uid="uid://dnblgqynq1t7l" path="res://addons/SunshineClouds2/SunshineClouds.gd" id="10_jugbg"]
 [ext_resource type="NoiseTexture3D" uid="uid://bnck2kxeg5bkg" path="res://addons/SunshineClouds2/NoiseTextures/SmallScaleNoise.tres" id="11_jgply"]
@@ -68,7 +68,7 @@ extra_large_used_as_mask = true
 mask_width_km = 512.0
 pre_pass_compute_shader = ExtResource("9_bt1pb")
 compute_shader = ExtResource("1_lebqt")
-post_pass_compute_shader = ExtResource("8_f8qfs")
+post_pass_compute_shader = ExtResource("8_lebqt")
 origin_offset = Vector3(0, 0, 0)
 wind_direction = Vector3(1, 0, 1)
 directional_lights_data = Array[Vector4]([Vector4(0.412799, 0.564261, -0.714988, 32), Vector4(1, 1, 1, 1)])

--- a/addons/SunshineClouds2/CloudsInc.txt
+++ b/addons/SunshineClouds2/CloudsInc.txt
@@ -11,6 +11,26 @@
 #define GODOT_VERSION_MAJOR 4
 #define GODOT_VERSION_MINOR 4
 
+#ifndef MSAA_ENABLED
+	#define MSAA_ENABLED 0
+#endif
+
+#if (!MSAA_ENABLED)
+	#define Sampler2DMSAA                              sampler2D
+	#define Image2DMSAA                                image2D
+	#define textureSizeMSAA(sampler_)                  textureSize(sampler_, 0)
+	#define textureSamplesMSAA(sampler_)               (1)
+	#define texelFetchMSAA(sampler_, P_, sample_)      texelFetch(sampler_, P_, 0)
+	#define imageStoreMSAA(image_, P_, sample_, data_) imageStore(image_, P_, data_)
+#else
+	#define Sampler2DMSAA                              sampler2DMS
+	#define Image2DMSAA                                image2DMS
+	#define textureSizeMSAA(sampler_)                  textureSize(sampler_)
+	#define textureSamplesMSAA(sampler_)               textureSamples(sampler_)
+	#define texelFetchMSAA(sampler_, P_, sample_)      texelFetch(sampler_, P_, sample_)
+	#define imageStoreMSAA(image_, P_, sample_, data_) imageStore(image_, P_, sample_, data_)
+#endif // !MSAA_ENABLED
+
 
 struct SceneData {
 	#if (GODOT_VERSION_MAJOR == 4) && (GODOT_VERSION_MINOR == 4)

--- a/addons/SunshineClouds2/Dock/CloudsEditorController.gd
+++ b/addons/SunshineClouds2/Dock/CloudsEditorController.gd
@@ -104,7 +104,7 @@ func InitialSceneLoad() -> void:
 		file.store_string(content)
 		file.close()
 		
-		EditorInterface.get_resource_filesystem().reimport_files(["res://addons/SunshineClouds2/SunshineCloudsCompute.glsl", "res://addons/SunshineClouds2/SunshineCloudsPostCompute.glsl", "res://addons/SunshineClouds2/SunshineCloudsPreCompute.glsl"])
+		EditorInterface.get_resource_filesystem().reimport_files(["res://addons/SunshineClouds2/SunshineCloudsCompute.glsl", "res://addons/SunshineClouds2/SunshineCloudsPostCompute.glsl", "res://addons/SunshineClouds2/SunshineCloudsPostCompute.msaa.glsl", "res://addons/SunshineClouds2/SunshineCloudsPreCompute.glsl", "res://addons/SunshineClouds2/SunshineCloudsDisplay.glsl", "res://addons/SunshineClouds2/SunshineCloudsDisplay.msaa.glsl"])
 		await get_tree().create_timer(0.1).timeout
 		if driver != null && driver.clouds_resource != null:
 			driver.clouds_resource.refresh_compute()

--- a/addons/SunshineClouds2/SunshineCloudsCompute.glsl
+++ b/addons/SunshineClouds2/SunshineCloudsCompute.glsl
@@ -419,10 +419,10 @@ void main() {
 		return;
 	}
 	
-	vec2 depthUV = vec2(float(uv.x) / float(size.x), float(uv.y) / float(size.y));
+	vec2 depthUV = (uv + 0.5) / vec2(size);
 	float depth = texture(depth_image, depthUV).r;
 
-	vec4 view = inverse(scene_data_block.data.projection_matrix) * vec4(depthUV*2.0-1.0,depth,1.0);
+	vec4 view = scene_data_block.data.inv_projection_matrix * vec4(depthUV*2.0-1.0,depth,1.0);
 	view.xyz /= view.w;
 	float linear_depth = length(view); //used to calculate depth based on the view angle, idk just works.
 	//4.4 doesn't work with this
@@ -435,7 +435,7 @@ void main() {
 	vec2 ndc = clipUV * 2.0 - 1.0;	
 	// Convert NDC to view space coordinates
 	vec4 clipPos = vec4(ndc, 0.0, 1.0);
-	vec4 viewPos = inverse(scene_data_block.data.projection_matrix) * clipPos;
+	vec4 viewPos = scene_data_block.data.inv_projection_matrix * clipPos;
 	viewPos.xyz /= viewPos.w;
 	
 	vec3 rd_world = normalize(viewPos.xyz);

--- a/addons/SunshineClouds2/SunshineCloudsDisplay.glsl
+++ b/addons/SunshineClouds2/SunshineCloudsDisplay.glsl
@@ -1,0 +1,14 @@
+#[vertex]
+#version 450
+
+#include "./CloudsInc.txt"
+
+#define STAGE_VERTEX
+#include "./SunshineCloudsDisplay.rast"
+#undef STAGE_VERTEX
+
+#[fragment]
+#version 450
+
+#include "./CloudsInc.txt"
+#include "./SunshineCloudsDisplay.rast"

--- a/addons/SunshineClouds2/SunshineCloudsDisplay.glsl.import
+++ b/addons/SunshineClouds2/SunshineCloudsDisplay.glsl.import
@@ -1,0 +1,14 @@
+[remap]
+
+importer="glsl"
+type="RDShaderFile"
+uid="uid://dnehn55ps7gfb"
+path="res://.godot/imported/SunshineCloudsDisplay.glsl-602d5e21efc2f12bb69e9e6145b7ede3.res"
+
+[deps]
+
+source_file="res://addons/SunshineClouds2/SunshineCloudsDisplay.glsl"
+dest_files=["res://.godot/imported/SunshineCloudsDisplay.glsl-602d5e21efc2f12bb69e9e6145b7ede3.res"]
+
+[params]
+

--- a/addons/SunshineClouds2/SunshineCloudsDisplay.msaa.glsl
+++ b/addons/SunshineClouds2/SunshineCloudsDisplay.msaa.glsl
@@ -1,0 +1,18 @@
+#[vertex]
+#version 450
+
+#define MSAA_ENABLED 1
+
+#include "./CloudsInc.txt"
+
+#define STAGE_VERTEX
+#include "./SunshineCloudsDisplay.rast"
+#undef STAGE_VERTEX
+
+#[fragment]
+#version 450
+
+#define MSAA_ENABLED 1
+
+#include "./CloudsInc.txt"
+#include "./SunshineCloudsDisplay.rast"

--- a/addons/SunshineClouds2/SunshineCloudsDisplay.msaa.glsl.import
+++ b/addons/SunshineClouds2/SunshineCloudsDisplay.msaa.glsl.import
@@ -1,0 +1,14 @@
+[remap]
+
+importer="glsl"
+type="RDShaderFile"
+uid="uid://jri8gylu1f8i"
+path="res://.godot/imported/SunshineCloudsDisplay.msaa.glsl-ef574cff8a1a3b7e48cfd96d8b54b6cf.res"
+
+[deps]
+
+source_file="res://addons/SunshineClouds2/SunshineCloudsDisplay.msaa.glsl"
+dest_files=["res://.godot/imported/SunshineCloudsDisplay.msaa.glsl-ef574cff8a1a3b7e48cfd96d8b54b6cf.res"]
+
+[params]
+

--- a/addons/SunshineClouds2/SunshineCloudsDisplay.rast
+++ b/addons/SunshineClouds2/SunshineCloudsDisplay.rast
@@ -1,0 +1,21 @@
+layout(binding = 0) uniform Sampler2DMSAA screen_texture;
+
+#ifdef STAGE_VERTEX
+
+layout(location = 0) in vec2 VertPos;
+
+void main() {
+	gl_Position = vec4(VertPos, 0.0, 1.0);
+}
+
+#else
+
+layout(location = 0) out vec4 RastColor;
+
+void main() {
+	vec2 screen_uv = gl_FragCoord.xy / vec2(textureSizeMSAA(screen_texture));
+	vec3 screen_color = texelFetchMSAA(screen_texture, ivec2(gl_FragCoord.xy), gl_SampleID).rgb;
+	RastColor = vec4(screen_color, 1.0);
+}
+
+#endif

--- a/addons/SunshineClouds2/SunshineCloudsPostCompute.comp
+++ b/addons/SunshineClouds2/SunshineCloudsPostCompute.comp
@@ -1,0 +1,378 @@
+#define PI 3.141592
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(binding = 0) uniform sampler2D input_data_image;
+layout(binding = 1) uniform sampler2D input_color_image;
+layout(rgba16f, binding = 2) uniform image2D reflections_sample;
+layout(binding = 3) uniform Sampler2DMSAA input_screen_image;
+layout(rgba16f, binding = 4) restrict uniform Image2DMSAA output_screen_image;
+layout(binding = 5) uniform Sampler2DMSAA depth_image;
+
+
+layout(binding = 6) uniform uniformBuffer {
+	GenericData data;
+} genericData;
+
+layout(binding = 7) uniform LightsBuffer {
+	DirectionalLight directionalLights[4];
+	PointLight pointLights[128];
+	PointEffector pointEffectors[64];
+};
+
+layout(binding = 8, std140) uniform SceneDataBlock {
+	SceneData data;
+	SceneData prev_data;
+} scene_data_block;
+
+
+// Helpers
+float remap(float value, float min1, float max1, float min2, float max2) {
+  return min2 + (value - min1) * (max2 - min2) / (max1 - min1);
+}
+
+float w0(float a)
+{
+    return (1.0/6.0)*(a*(a*(-a + 3.0) - 3.0) + 1.0);
+}
+
+float w1(float a)
+{
+    return (1.0/6.0)*(a*a*(3.0*a - 6.0) + 4.0);
+}
+
+float w2(float a)
+{
+    return (1.0/6.0)*(a*(a*(-3.0*a + 3.0) + 3.0) + 1.0);
+}
+
+float w3(float a)
+{
+    return (1.0/6.0)*(a*a*a);
+}
+
+// g0 and g1 are the two amplitude functions
+float g0(float a)
+{
+    return w0(a) + w1(a);
+}
+
+float g1(float a)
+{
+    return w2(a) + w3(a);
+}
+
+// h0 and h1 are the two offset functions
+float h0(float a)
+{
+    return -1.0 + w1(a) / (w0(a) + w1(a));
+}
+
+float h1(float a)
+{
+    return 1.0 + w3(a) / (w2(a) + w3(a));
+}
+
+// Sampling
+
+vec4 texture2D_bicubic(sampler2D tex, vec2 uv, vec2 res)
+{
+	uv = uv*res + 0.5;
+	vec2 iuv = floor( uv );
+	vec2 fuv = fract( uv );
+
+	float g0x = g0(fuv.x);
+	float g1x = g1(fuv.x);
+	float h0x = h0(fuv.x);
+	float h1x = h1(fuv.x);
+	float h0y = h0(fuv.y);
+	float h1y = h1(fuv.y);
+
+	vec2 p0 = (vec2(iuv.x + h0x, iuv.y + h0y) - 0.5) / res;
+	vec2 p1 = (vec2(iuv.x + h1x, iuv.y + h0y) - 0.5) / res;
+	vec2 p2 = (vec2(iuv.x + h0x, iuv.y + h1y) - 0.5) / res;
+	vec2 p3 = (vec2(iuv.x + h1x, iuv.y + h1y) - 0.5) / res;
+
+    return g0(fuv.y) * (g0x * texture(tex, p0)  +
+                        g1x * texture(tex, p1)) +
+           g1(fuv.y) * (g0x * texture(tex, p2)  +
+                        g1x * texture(tex, p3));
+}
+
+vec4 radialBlurColor(vec4 startColor, sampler2D colorImage, sampler2D depthImage, vec2 uv, vec2 size, float Directions, float blurVertical, float blurHorizontal, float Quality){
+    float Pi = 6.28318530718;
+    float count = 1.0;
+	float theoreticalMaxCount =  Directions * Quality;
+	//float stepLerp = 1.0 / theoreticalMaxCount;
+    vec4 Color = startColor;
+	//float CurrentDepth = startingDepth;
+	vec2 newUV = uv;
+    for( float d=0.0; d<Pi; d+=Pi/Directions)
+    {
+		for(float i=1.0/Quality; i<=1.0; i+=1.0/Quality)
+        {
+			newUV = uv + vec2(cos(d) * blurHorizontal * i, sin(d) * blurVertical * i);
+			Color += texture2D_bicubic(colorImage, newUV, size);
+			count += 1.0;
+			//float newDepth = texture(depthImage, newUV).g;
+			//startingDepth = max(startingDepth, texture(depthImage, newUV).g);
+			// if (startingDepth - newDepth > genericData.max_step_distance){
+			// 	CurrentDepth = max(CurrentDepth, newDepth);
+			// 	Color += texture2D_bicubic(colorImage, newUV, size);
+			// 	count += 1.0;
+			// }
+        }
+    }
+	//startingDepth = CurrentDepth
+    Color /= count;
+    return Color;
+}
+
+vec4 radialBlurData(vec4 startColor, float linear_depth, sampler2D image, vec2 uv, float Directions, float blurVertical, float blurHorizontal, float Quality){
+    float Pi = 6.28318530718;
+    float count = 1.0;
+	//float theoreticalMaxCount =  Directions * Quality;
+	//float stepLerp = 1.0 / theoreticalMaxCount;
+    vec4 Color = startColor;
+	//float originalDepth = Color.r;
+	//bool isNear = originalDepth < linear_depth;
+
+	//float meanDistancesFar = 0.0;
+    for( float d=0.0; d<Pi; d+=Pi/Directions)
+    {
+		for(float i=1.0/Quality; i<=1.0; i+=1.0/Quality)
+        {
+			Color = max(Color, texture(image, uv + vec2(cos(d) * blurHorizontal * i, sin(d) * blurVertical * i)));
+
+			//sampled = texture(image, uv + vec2(cos(d) * blurHorizontal * i, sin(d) * blurVertical * i));
+			//Color.rgb += sampled.rgb;
+			//Color.a = max(Color.a, sampled.a);
+			// if (abs(originalDepth - sampled) < 100.0){
+			// 	Color += texture(image, uv + vec2(cos(d) * blurHorizontal * i, sin(d) * blurVertical * i)).r;
+			// 	count += 1.0;
+			// }
+
+			// if (sampled > linear_depth){
+			// 	meanDistancesFar += 1.0;
+			// }
+			// else{
+			// 	meanDistancesFar -= 1.0;
+			// }
+			// maxDistance = max(maxDistance, sampled);
+			// minDistance = min(minDistance, sampled);
+			//count += 1.0;
+        }
+    }
+    return Color;
+}
+
+void sampleAtmospherics(
+	vec3 curPos,
+	float atmosphericHeight,
+	float distanceTraveled,
+	float Rayleighscaleheight,
+	float Miescaleheight,
+	vec3 RayleighScatteringCoef,
+	float MieScatteringCoef,
+	float atmosphericDensity,
+	float density,
+	inout vec3 totalRlh,
+	inout vec3 totalMie,
+	inout float iOdRlh,
+	inout float iOdMie)
+	{
+	float iHeight = curPos.y / atmosphericHeight;
+	float odStepRlh = exp(-iHeight / Rayleighscaleheight) * distanceTraveled;
+	float odStepMie = exp(-iHeight / Miescaleheight) * distanceTraveled;
+	iOdRlh += odStepRlh;
+	iOdMie += odStepMie;
+
+	vec3 attn = exp(-(MieScatteringCoef * (iOdMie + Miescaleheight) + RayleighScatteringCoef * (iOdRlh + Rayleighscaleheight))) * atmosphericDensity * (1.0 - clamp(iHeight, 0.0, 1.0));
+	totalRlh += odStepRlh * attn * (1.0 - density);
+	totalMie += odStepMie * attn * (1.0 - density);
+}
+
+vec4 sampleAllAtmospherics(
+	vec3 worldPos,
+	vec3 rayDirection,
+	float linear_depth,
+	float highestDensityDistance,
+	float density,
+	float stepDistance,
+	float stepCount,
+	float atmosphericDensity,
+	vec3 sunDirection,
+	vec3 sunlightColor,
+	vec3 ambientLight)
+	{
+	vec3 totalRlh = vec3(0,0,0);
+    vec3 totalMie = vec3(0,0,0);
+	float iOdRlh = 0.0;
+    float iOdMie = 0.0;
+	// float odStepRlh = 0.0;
+	// float odStepMie = 0.0;
+
+	const float atmosphericHeight = 40000.0;
+	const vec3 RayleighScatteringCoef = vec3(5.5e-6, 13.0e-6, 22.4e-6);
+	const float Rayleighscaleheight = 8e3;
+	const float MieScatteringCoef = 21e-6;
+	const float Miescaleheight = 1.2e3;
+	const float MieprefferedDirection = 0.758;
+
+	// Calculate the Rayleigh and Mie phases.
+    float mu = dot(rayDirection, sunDirection);
+    float mumu = mu * mu;
+    float gg = MieprefferedDirection * MieprefferedDirection;
+    float pRlh = 3.0 / (16.0 * PI) * (1.0 + mumu);
+    float pMie = 3.0 / (8.0 * PI) * ((1.0 - gg) * (mumu + 1.0)) / (pow(1.0 + gg - 2.0 * mu * MieprefferedDirection, 1.5) * (2.0 + gg));
+
+	vec3 curPos = vec3(0.0);
+	float traveledDistance = 0.0;
+	//bool sampledDistanceAtmo = false;
+	float currentWeight = 0.0;
+	float sampleCount = 0.0;
+
+	for (float i = 0.0; i < stepCount; i++) {
+		traveledDistance = stepDistance * (i + 1);
+
+		currentWeight = density * (1.0 - clamp((highestDensityDistance - traveledDistance) / stepDistance, 0.0, 1.0));
+
+		if (traveledDistance > linear_depth || currentWeight >= 1.0){
+			traveledDistance = traveledDistance - stepDistance;
+			currentWeight = 1.0 - clamp((linear_depth - traveledDistance) / stepDistance, 0.0, 1.0);
+			sampleAtmospherics(curPos, atmosphericHeight, stepDistance, Rayleighscaleheight, Miescaleheight, RayleighScatteringCoef, MieScatteringCoef, atmosphericDensity, currentWeight, totalRlh, totalMie, iOdRlh, iOdMie);
+			break;
+		}
+		sampleCount += 1.0;
+
+		curPos = worldPos + rayDirection * traveledDistance;
+
+		sampleAtmospherics(curPos, atmosphericHeight, stepDistance, Rayleighscaleheight, Miescaleheight, RayleighScatteringCoef, MieScatteringCoef, atmosphericDensity, currentWeight, totalRlh, totalMie, iOdRlh, iOdMie);
+	}
+
+	// pRlh *= (1.0 - lightingWeight);
+	// pMie *= (1.0 - lightingWeight);
+
+	float AtmosphericsDistancePower = length(vec3(RayleighScatteringCoef * totalRlh + MieScatteringCoef * totalMie));
+	vec3 atmospherics = 22.0 * (ambientLight * RayleighScatteringCoef * totalRlh + pMie * MieScatteringCoef * sunlightColor * totalMie) / sampleCount;
+	return vec4(atmospherics, AtmosphericsDistancePower);
+}
+
+
+void main() {
+    ivec2 uv = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 lowres_size = ivec2(genericData.data.raster_size);
+
+    int resolutionScale = int(genericData.data.resolutionscale);
+    ivec2 size = lowres_size * resolutionScale;
+
+
+	vec2 depthUV = (uv + 0.5) / vec2(size);
+	depthUV = clamp(depthUV, vec2(0.0), vec2(1.0));
+
+	vec2 accumUV = depthUV;
+
+	vec2 lowres_sizefloat = vec2(lowres_size);
+	vec4 currentAccumilation = vec4(0.0);
+	vec4 currentColorData = vec4(0.0);
+
+	currentAccumilation = texture(input_color_image, accumUV);
+	currentColorData = texture(input_data_image, accumUV);
+
+	float sampledDepth = currentColorData.r;
+	float traveledDistance = currentColorData.g;
+	float firstTraveledDistance = currentColorData.b;
+
+	float minstep = genericData.data.min_step_distance;
+	float maxstep = genericData.data.max_step_distance;
+
+	float blurPower = genericData.data.blurPower;
+	float maxTheoreticalStep = genericData.data.max_step_count * maxstep;
+
+	blurPower = mix(blurPower, 0.0, currentColorData.b / maxTheoreticalStep);
+
+	if (blurPower > 0.0){
+		float blurHorizontal = blurPower / float(size.x);
+		float blurVertical = blurPower / float(size.y);
+		float blurQuality = genericData.data.blurQuality;
+		currentAccumilation = radialBlurColor(currentAccumilation, input_color_image, input_data_image, accumUV, lowres_sizefloat, blurQuality * 4.0, blurVertical, blurHorizontal, blurQuality);
+	}
+
+	// Convert screen coordinates to normalized device coordinates
+	vec2 clipUV = vec2(depthUV.x, depthUV.y);
+	vec2 ndc = clipUV * 2.0 - 1.0;
+	// Convert NDC to view space coordinates
+	vec4 clipPos = vec4(ndc, 0.0, 1.0);
+	vec4 viewPos = scene_data_block.data.inv_projection_matrix * clipPos;
+	viewPos.xyz /= viewPos.w;
+
+	vec3 rd_world = normalize(viewPos.xyz);
+	rd_world = mat3(scene_data_block.data.main_cam_inv_view_matrix) * rd_world;
+	// Define the ray properties
+
+	vec3 raydirection = normalize(rd_world);
+	vec3 rayOrigin = scene_data_block.data.main_cam_inv_view_matrix[3].xyz; //center of camera for the ray origin, not worried about the screen width playing in, as it's for clouds.
+
+	vec4 averageColor = vec4(0.0);
+
+	for (int sampleIdx = 0; sampleIdx < textureSamplesMSAA(depth_image); ++sampleIdx) {
+		float depth = texelFetchMSAA(depth_image, uv, sampleIdx).r;
+		vec4 view = scene_data_block.data.inv_projection_matrix * vec4(depthUV*2.0-1.0,depth,1.0);
+		view.xyz /= view.w;
+		float linear_depth = length(view); //used to calculate depth based on the view angle, idk just works.
+
+		float density = clamp(currentAccumilation.a, 0.0, 1.0);
+
+		float lerp = 0.0;
+		bool debugCollisions = false;
+		if (firstTraveledDistance > linear_depth){
+			lerp = 1.0;
+		}
+		else if (traveledDistance > linear_depth){
+			float firsttravelblend = mix(1.0 - clamp((traveledDistance - firstTraveledDistance) / minstep, 0.0, 1.0), 1.0, clamp(firstTraveledDistance / maxstep, 0.0, 1.0));
+			lerp = (clamp((traveledDistance - linear_depth) / (traveledDistance - firstTraveledDistance), 0.0, 1.0)) * firsttravelblend;
+		}
+		density *= smoothstep(0.0, minstep, linear_depth);
+		density = clamp(density - lerp, 0.0, 1.0);
+		float groundLinearFade = mix(smoothstep(maxTheoreticalStep, maxTheoreticalStep, linear_depth), 1.0, genericData.data.fogEffectGround);
+
+		vec4 color = texelFetchMSAA(input_screen_image, uv, sampleIdx);
+
+		vec3 ambientfogdistancecolor = genericData.data.ambientfogdistancecolor.rgb * genericData.data.ambientfogdistancecolor.a;
+		float atmosphericDensity = genericData.data.atmospheric_density;
+		float directionalLightCount = genericData.data.directionalLightsCount;
+		if (directionalLightCount > 0.0){
+			for (float i = 0.0; i < directionalLightCount; i++){
+				DirectionalLight light = directionalLights[int(i)];
+				vec3 sundir = light.direction.xyz;
+				//sampleColor = sundir;
+				float sunUpWeight = smoothstep(0.0, 0.4, dot(sundir, vec3(0.0, 1.0, 0.0)));
+				float sundensityaffect = clamp(dot(sundir, raydirection), 0.0, 1.0);
+				sundensityaffect = min(clamp(1.0 - (sundensityaffect * density), 0.0, 1.0), 1.0 - (sundensityaffect * clamp(maxTheoreticalStep - linear_depth, 0.0, 1.0)));
+				float lightPower = light.color.a * sunUpWeight * sundensityaffect;
+				vec4 atmosphericData = sampleAllAtmospherics(rayOrigin, raydirection, linear_depth, traveledDistance, 0.0,  min(linear_depth, maxTheoreticalStep)  / 10.0, 10.0, atmosphericDensity, sundir, light.color.rgb * lightPower, ambientfogdistancecolor);
+				color.rgb = mix(color.rgb, atmosphericData.rgb, clamp(atmosphericData.a * groundLinearFade, 0.0, 1.0)); //causes jitter in the sky
+			}
+		}
+
+
+		color.rgb = mix(color.rgb, currentAccumilation.rgb, density);
+
+		if (debugCollisions){
+			color.rgb = vec3(lerp);
+		}
+
+		imageStoreMSAA(output_screen_image, uv, sampleIdx, color);
+
+		averageColor.rgb += color.rgb;
+	}
+
+	averageColor /= textureSamplesMSAA(depth_image);
+
+	if (resolutionScale != 1){
+		imageStore(reflections_sample, ivec2(accumUV * vec2(lowres_size)), vec4(averageColor.rgb, traveledDistance));
+	}
+	else{
+		imageStore(reflections_sample, uv, vec4(averageColor.rgb, traveledDistance));
+	}
+}

--- a/addons/SunshineClouds2/SunshineCloudsPostCompute.glsl.import
+++ b/addons/SunshineClouds2/SunshineCloudsPostCompute.glsl.import
@@ -2,7 +2,7 @@
 
 importer="glsl"
 type="RDShaderFile"
-uid="uid://chxheyp4eohbc"
+uid="uid://cqhejbalsrvjp"
 path="res://.godot/imported/SunshineCloudsPostCompute.glsl-fc422a4d7d896e6886b97028d6f47ec2.res"
 
 [deps]

--- a/addons/SunshineClouds2/SunshineCloudsPostCompute.msaa.glsl
+++ b/addons/SunshineClouds2/SunshineCloudsPostCompute.msaa.glsl
@@ -1,5 +1,7 @@
 #[compute]
 #version 450
 
+#define MSAA_ENABLED 1
+
 #include "./CloudsInc.txt"
 #include "./SunshineCloudsPostCompute.comp"

--- a/addons/SunshineClouds2/SunshineCloudsPostCompute.msaa.glsl.import
+++ b/addons/SunshineClouds2/SunshineCloudsPostCompute.msaa.glsl.import
@@ -1,0 +1,14 @@
+[remap]
+
+importer="glsl"
+type="RDShaderFile"
+uid="uid://cpef10h5lggny"
+path="res://.godot/imported/SunshineCloudsPostCompute.msaa.glsl-80be32b2c971150f963527b62159d785.res"
+
+[deps]
+
+source_file="res://addons/SunshineClouds2/SunshineCloudsPostCompute.msaa.glsl"
+dest_files=["res://.godot/imported/SunshineCloudsPostCompute.msaa.glsl-80be32b2c971150f963527b62159d785.res"]
+
+[params]
+


### PR DESCRIPTION
Implements MSAA compatibility. Should close #6.
Since the screen texture when MSAA is enabled doesn't have `TEXTURE_USAGE_STORAGE_BIT`, a fragment shader is used to write the output of the post pass. This shader is used both with and without MSAA.
With MSAA turned on, the post pass composites and calculates atmospherics/lighting per sample. So there might be some performance impact when a lot of directional lights are used.
The clouds are still marched per-pixel. There is some artifacting, but maybe this can be solved by having the pre pass resolve the depth texture with a min or max operator.
There is some file inflation due to the fact that Godot doesn't provide any way of explicitly _compiling_ Godot-style GLSL (as opposed to `load()` via `ResourceImporterShaderFile`).