### PR TITLE
Fix clouds on Godot 4.7 + threaded light race

### DIFF
--- a/addons/SunshineClouds2/CloudsInc.comp
+++ b/addons/SunshineClouds2/CloudsInc.comp
@@ -242,6 +242,26 @@ struct SceneData {
 	#endif
 };
 
+// Version-independent camera block. The stock addon read Godot's private
+// SceneData UBO (above), whose byte layout is mirrored per engine version and
+// has no 4.7 entry -> it breaks on 4.7. Instead we pack exactly the fields the
+// clouds shaders use from stable public API (get_cam_transform /
+// get_cam_projection) into our own UBO. Field names match what the shader body
+// already references so the raymarch/reprojection code is unchanged.
+//   inv_projection_matrix    : clip -> view
+//   main_cam_inv_view_matrix : view -> world (camera global transform)
+//   view_matrix              : world -> view
+//   projection_matrix        : view -> clip
+struct CameraData {
+	mat4 inv_projection_matrix;
+	mat4 main_cam_inv_view_matrix;
+	mat4 view_matrix;
+	mat4 projection_matrix;
+	float z_far;
+	float z_near;
+	vec2 _cam_pad;
+};
+
 struct GenericData{
 	vec3 extralargenoiseposition;
 	float extralargenoisescale;

--- a/addons/SunshineClouds2/SunshineClouds.gd
+++ b/addons/SunshineClouds2/SunshineClouds.gd
@@ -131,6 +131,14 @@ var linear_sampler_no_repeat : RID = RID()
 
 var general_data_buffer : RID = RID()
 var light_data_buffer : RID = RID()
+# Version-independent camera UBO (binding 17 compute / 8 postpass). Two CameraData
+# structs (current + previous frame), each 272 bytes std140 (4 mat4 + z_far/z_near
+# + 2-float pad). See CloudsInc.comp::CameraData.
+const CAMERA_UBO_BYTES : int = 544
+var camera_override_buffer : RID = RID()
+var _prev_cam_transform : Transform3D = Transform3D.IDENTITY
+var _prev_view_proj : Projection = Projection.IDENTITY
+var _has_prev_camera : bool = false
 var point_sample_data_buffer : RID = RID()
 var accumulation_textures : Array[RID] = []
 var resized_depth : RID = RID()
@@ -243,6 +251,10 @@ func clear_compute():
 		if light_data_buffer.is_valid():
 			rd.free_rid(light_data_buffer)
 		light_data_buffer = RID()
+
+		if camera_override_buffer.is_valid():
+			rd.free_rid(camera_override_buffer)
+		camera_override_buffer = RID()
 		
 		if point_sample_data_buffer.is_valid():
 			rd.free_rid(point_sample_data_buffer)
@@ -650,7 +662,13 @@ func _render_callback(effect_callback_type, render_data):
 					point_sample_data_uniform.add_id(point_sample_data_buffer)
 					uniforms_array.append(point_sample_data_uniform)
 					
-					var cameraData = rendersceneData.get_uniform_buffer()
+					# Our own version-independent camera UBO (replaces Godot's private
+					# SceneData UBO, which has no 4.7 byte-layout mirror and delivers a
+					# wrong camera in multi-camera setups). Two CameraData structs
+					# (current + previous frame) = 2 * 272 bytes. Packed each frame in
+					# update_matrices() from get_cam_transform/get_cam_projection.
+					camera_override_buffer = rd.uniform_buffer_create(CAMERA_UBO_BYTES)
+					var cameraData = camera_override_buffer
 					var camera_data_uniform = RDUniform.new()
 					camera_data_uniform.uniform_type = RenderingDevice.UNIFORM_TYPE_UNIFORM_BUFFER
 					camera_data_uniform.binding = 17
@@ -1042,6 +1060,70 @@ func update_matrices(camera_tr, view_proj, new_size: Vector2i):
 	
 	# Copy to byte buffer
 	rd.buffer_update(general_data_buffer, 0, general_data.size(), general_data)
+
+	update_camera_data(camera_tr, view_proj)
+
+
+## Packs the version-independent camera UBO (binding 17 / postpass 8) with the
+## current and previous frame's matrices, derived from get_cam_transform() /
+## get_cam_projection() - no dependency on Godot's private SceneData layout.
+## Layout per CameraData (272 bytes, std140), x2 (current, then previous):
+##   [  0] inv_projection_matrix    (mat4, clip->view)
+##   [ 64] main_cam_inv_view_matrix (mat4, view->world = camera transform)
+##   [128] view_matrix              (mat4, world->view)
+##   [192] projection_matrix        (mat4, view->clip)
+##   [256] z_far, z_near, pad, pad
+func update_camera_data(camera_tr : Transform3D, view_proj : Projection):
+	if not camera_override_buffer.is_valid():
+		return
+	# First frame: seed prev = current so reprojection has valid matrices.
+	if not _has_prev_camera:
+		_prev_cam_transform = camera_tr
+		_prev_view_proj = view_proj
+		_has_prev_camera = true
+
+	var bytes : PackedByteArray = []
+	bytes.resize(CAMERA_UBO_BYTES)
+
+	_encode_camera_data(bytes, 0, camera_tr, view_proj)
+	_encode_camera_data(bytes, 272, _prev_cam_transform, _prev_view_proj)
+
+	rd.buffer_update(camera_override_buffer, 0, CAMERA_UBO_BYTES, bytes)
+
+	_prev_cam_transform = camera_tr
+	_prev_view_proj = view_proj
+
+
+## Encode one CameraData block (272 bytes) at byte offset `o`.
+func _encode_camera_data(bytes : PackedByteArray, o : int, cam_tr : Transform3D, proj : Projection):
+	_encode_projection_mat4(bytes, o + 0, proj.inverse())          # inv_projection_matrix
+	_encode_transform_mat4(bytes, o + 64, cam_tr)                  # main_cam_inv_view_matrix (view->world)
+	_encode_transform_mat4(bytes, o + 128, cam_tr.affine_inverse()) # view_matrix (world->view)
+	_encode_projection_mat4(bytes, o + 192, proj)                  # projection_matrix (view->clip)
+	bytes.encode_float(o + 256, proj.get_z_far())
+	bytes.encode_float(o + 260, proj.get_z_near())
+	bytes.encode_float(o + 264, 0.0)
+	bytes.encode_float(o + 268, 0.0)
+
+
+## Encode a Transform3D as a column-major GLSL mat4 (16 floats) at byte offset.
+## Columns 0-2 are the basis axes (image of local x/y/z), column 3 is the origin.
+func _encode_transform_mat4(bytes : PackedByteArray, o : int, t : Transform3D):
+	var b : Basis = t.basis
+	var p : Vector3 = t.origin
+	bytes.encode_float(o + 0,  b.x.x); bytes.encode_float(o + 4,  b.x.y); bytes.encode_float(o + 8,  b.x.z); bytes.encode_float(o + 12, 0.0)
+	bytes.encode_float(o + 16, b.y.x); bytes.encode_float(o + 20, b.y.y); bytes.encode_float(o + 24, b.y.z); bytes.encode_float(o + 28, 0.0)
+	bytes.encode_float(o + 32, b.z.x); bytes.encode_float(o + 36, b.z.y); bytes.encode_float(o + 40, b.z.z); bytes.encode_float(o + 44, 0.0)
+	bytes.encode_float(o + 48, p.x);   bytes.encode_float(o + 52, p.y);   bytes.encode_float(o + 56, p.z);   bytes.encode_float(o + 60, 1.0)
+
+
+## Encode a Projection as a column-major GLSL mat4 (16 floats) at byte offset.
+## Projection.x/.y/.z/.w are the columns.
+func _encode_projection_mat4(bytes : PackedByteArray, o : int, m : Projection):
+	bytes.encode_float(o + 0,  m.x.x); bytes.encode_float(o + 4,  m.x.y); bytes.encode_float(o + 8,  m.x.z); bytes.encode_float(o + 12, m.x.w)
+	bytes.encode_float(o + 16, m.y.x); bytes.encode_float(o + 20, m.y.y); bytes.encode_float(o + 24, m.y.z); bytes.encode_float(o + 28, m.y.w)
+	bytes.encode_float(o + 32, m.z.x); bytes.encode_float(o + 36, m.z.y); bytes.encode_float(o + 40, m.z.z); bytes.encode_float(o + 44, m.z.w)
+	bytes.encode_float(o + 48, m.w.x); bytes.encode_float(o + 52, m.w.y); bytes.encode_float(o + 56, m.w.z); bytes.encode_float(o + 60, m.w.w)
 
 
 func update_lights():

--- a/addons/SunshineClouds2/SunshineCloudsCompute.glsl
+++ b/addons/SunshineClouds2/SunshineCloudsCompute.glsl
@@ -42,8 +42,8 @@ layout(binding = 16, std430) restrict buffer SamplePointsBuffer {
 
 
 layout(binding = 17, std140) uniform SceneDataBlock {
-	SceneData data;
-	SceneData prev_data;
+	CameraData data;
+	CameraData prev_data;
 } scene_data_block;
 
 // Our push constant
@@ -428,9 +428,13 @@ void main() {
 	vec4 view = scene_data_block.data.inv_projection_matrix * vec4(depthUV*2.0-1.0,depth,1.0);
 	view.xyz /= view.w;
 	float linear_depth = length(view); //used to calculate depth based on the view angle, idk just works.
-	//4.4 doesn't work with this
-	if (linear_depth >= scene_data_block.data.z_far){ 
-		linear_depth *= 100.0;
+	// Sky/far pixels: Godot uses reverse-Z, so cleared sky reads depth == 0.
+	// Push the ray's max distance far past the camera far plane so distant clouds
+	// still draw. (The stock test compared length(view) >= z_far, which is
+	// marginal exactly at screen center where the forward ray length ~= z_far,
+	// carving an oval hole of missing sky/fog there.)
+	if (depth <= 0.0){
+		linear_depth = 1e9;
 	}
 	
 	// Convert screen coordinates to normalized device coordinates
@@ -871,39 +875,26 @@ void main() {
 	//accumulation preperation:
 	float finalDensityDistance = min(traveledDistance, highestDensityDistance);
 	vec3 worldFinalPos = rayOrigin + raydirection * traveledDistance;
+	// Camera movement this frame (used only by the accumulation-break heuristic
+	// below, via travelspeed). We do NOT add this to worldFinalPos: that
+	// camera-relative term compensated for Godot's internal camera-relative
+	// rendering, but our matrices are absolute world-space, so adding it cancels
+	// parallax and screen-locks the accumulated image to the camera.
 	vec3 delta = rayOrigin - scene_data_block.prev_data.main_cam_inv_view_matrix[3].xyz;
-	worldFinalPos += delta;
-	
+
 	vec4 reprojectedScreenPos = vec4(0.0);
 
-	#if ((GODOT_VERSION_MAJOR == 4) && (GODOT_VERSION_MINOR == 4)) || ((GODOT_VERSION_MAJOR == 4) && (GODOT_VERSION_MINOR == 5))
+	// Standard absolute reprojection: world -> prev view -> prev clip, using our
+	// own reliable prev-frame matrices (world->view is a real mat4 here, so no
+	// version-specific mat3x4 transpose needed).
+	vec4 reprojectedClipPos = scene_data_block.prev_data.view_matrix * vec4(worldFinalPos, 1.0);
 
-		//Prevview is already actually the inv_view (due to the way retrieving the transform works), so inversing it here is making it the equalivant of View_Matrix.
-		vec4 reprojectedClipPos = scene_data_block.prev_data.view_matrix * vec4(worldFinalPos, 1.0);
-		
-		reprojectedClipPos.z -= 0.01;
-		if (reprojectedClipPos.z > 0.0){
-			override = true;
-		}
-		
-		reprojectedScreenPos = scene_data_block.prev_data.projection_matrix * reprojectedClipPos;
-	#else
-		mat4 view_matrix = transpose(mat4(
-			scene_data_block.prev_data.view_matrix[0], 
-			scene_data_block.prev_data.view_matrix[1], 
-			scene_data_block.prev_data.view_matrix[2], 
-			vec4(0.0, 0.0, 0.0, 1.0)));
+	reprojectedClipPos.z -= 0.01;
+	if (reprojectedClipPos.z > 0.0){
+		override = true;
+	}
 
-		//Prevview is already actually the inv_view (due to the way retrieving the transform works), so inversing it here is making it the equalivant of View_Matrix.
-		vec4 reprojectedClipPos = view_matrix * vec4(worldFinalPos, 1.0);
-		
-		reprojectedClipPos.z -= 0.01;
-		if (reprojectedClipPos.z > 0.0){
-			override = true;
-		}
-		
-		reprojectedScreenPos = scene_data_block.prev_data.projection_matrix * reprojectedClipPos;
-	#endif
+	reprojectedScreenPos = scene_data_block.prev_data.projection_matrix * reprojectedClipPos;
 
 	// Convert clip space to normalized device coordinates
 	ndc = (reprojectedScreenPos.xy / reprojectedScreenPos.w);

--- a/addons/SunshineClouds2/SunshineCloudsDriver.gd
+++ b/addons/SunshineClouds2/SunshineCloudsDriver.gd
@@ -75,6 +75,33 @@ var _small_clouds_domain: float = 0.0
 
 var _updating_settings: bool = false
 
+# --- Multi-threaded rendering fix (thread_model = 2) --------------------------
+# clouds_resource IS the compositor effect: its fields are written here from
+# _process (main thread) and read in _render_callback (render thread). In Safe
+# mode that is the same thread and all is well; in threaded mode, the clear()
+# followed by the append()s in retrieve_texture_data opened a window where the
+# render thread could read an EMPTY light array — black clouds with a fringe
+# along the edge of the geometry.
+#
+# Fix: build the arrays in locals (node access has to stay on the main thread),
+# then hand them over to the effect from the render thread. The swap is thereby
+# serialised against _render_callback. In Safe mode call_on_render_thread runs
+# immediately: behaviour unchanged.
+#
+# The copies below are what _process compares against, so the main thread never
+# reads clouds_resource's arrays at all.
+var _dir_data_cache : Array[Vector4] = []
+var _point_data_cache : Array[Vector4] = []
+var _effector_data_cache : Array[Vector4] = []
+
+func _apply_lights_data(dir_data : Array[Vector4], point_data : Array[Vector4], effector_data : Array[Vector4]):
+	if clouds_resource == null:
+		return
+	clouds_resource.directional_lights_data = dir_data
+	clouds_resource.point_lights_data = point_data
+	clouds_resource.point_effector_data = effector_data
+	clouds_resource.lights_updated = true
+
 func _ready():
 	
 	if update_continuously:
@@ -112,8 +139,10 @@ func _process(delta : float):
 				clouds_resource.sampled_environment_fog_color = ambience_sample_environment.fog_light_color
 				#clouds_resource.cloud_ambient_color = ambience_sample_environment.fog_light_color
 			
-			if (tracked_directional_lights.size() * 2.0 != clouds_resource.directional_lights_data.size() \
-			or tracked_point_lights.size() * 2.0 != clouds_resource.point_lights_data.size()\
+			# Comparisons run against the driver's own copies, never against
+			# clouds_resource's arrays: those now belong to the render thread.
+			if (tracked_directional_lights.size() * 2.0 != _dir_data_cache.size() \
+			or tracked_point_lights.size() * 2.0 != _point_data_cache.size()\
 			or tracked_directional_lights.size() != tracked_directional_light_shadow_steps.size()):
 				
 				retrieve_texture_data()
@@ -122,21 +151,21 @@ func _process(delta : float):
 			for i in range(tracked_directional_lights.size()):
 				if tracked_directional_lights[i] == null:
 					continue
-				if direction_light_data_changed(tracked_directional_lights[i], tracked_directional_light_shadow_steps[i], clouds_resource.directional_lights_data[i * 2], clouds_resource.directional_lights_data[i * 2 + 1]):
+				if direction_light_data_changed(tracked_directional_lights[i], tracked_directional_light_shadow_steps[i], _dir_data_cache[i * 2], _dir_data_cache[i * 2 + 1]):
 					retrieve_texture_data()
 					return
 			
 			for i in range(tracked_point_lights.size()):
 				if tracked_point_lights[i] == null:
 					continue
-				if point_light_data_changed(tracked_point_lights[i], clouds_resource.point_lights_data[i * 2], clouds_resource.point_lights_data[i * 2 + 1]):
+				if point_light_data_changed(tracked_point_lights[i], _point_data_cache[i * 2], _point_data_cache[i * 2 + 1]):
 					retrieve_texture_data()
 					return
 			
 			for i in range(tracked_point_effectors.size()):
 				if tracked_point_effectors[i] == null:
 					continue
-				if point_effector_data_changed(tracked_point_effectors[i], clouds_resource.point_effector_data[i * 2], clouds_resource.point_effector_data[i * 2 + 1]):
+				if point_effector_data_changed(tracked_point_effectors[i], _effector_data_cache[i * 2], _effector_data_cache[i * 2 + 1]):
 					retrieve_texture_data()
 					return
 			
@@ -211,9 +240,11 @@ func retrieve_texture_data():
 		_medium_clouds_domain = clouds_resource.medium_noise_scale / 2.0
 		_small_clouds_domain = clouds_resource.small_noise_scale / 2.0
 		
-		clouds_resource.directional_lights_data.clear()
-		clouds_resource.point_lights_data.clear()
-		clouds_resource.point_effector_data.clear()
+		# Arrays built LOCALLY: until they are handed over to the effect, the render
+		# thread keeps seeing the old, complete ones. No empty window.
+		var new_dir_data : Array[Vector4] = []
+		var new_point_data : Array[Vector4] = []
+		var new_effector_data : Array[Vector4] = []
 		
 		if not tracked_directional_light_shadow_steps:
 			tracked_directional_light_shadow_steps = []
@@ -226,26 +257,32 @@ func retrieve_texture_data():
 			if tracked_directional_lights[i] != null:
 				var light = tracked_directional_lights[i]
 				var look_dir = light.global_transform.basis.z.normalized()
-				clouds_resource.directional_lights_data.append(Vector4(look_dir.x, look_dir.y, look_dir.z, tracked_directional_light_shadow_steps[i]))
-				clouds_resource.directional_lights_data.append(Vector4(light.light_color.r, light.light_color.g, light.light_color.b, round(light.light_color.a * light.light_energy * directional_light_power_multiplier * 10.0) / 10.0))
+				new_dir_data.append(Vector4(look_dir.x, look_dir.y, look_dir.z, tracked_directional_light_shadow_steps[i]))
+				new_dir_data.append(Vector4(light.light_color.r, light.light_color.g, light.light_color.b, round(light.light_color.a * light.light_energy * directional_light_power_multiplier * 10.0) / 10.0))
 		
 		for i in range(tracked_point_lights.size()):
 			if tracked_point_lights[i] != null:
 				var light = tracked_point_lights[i]
 				var light_pos = light.global_position
-				clouds_resource.point_lights_data.append(Vector4(light_pos.x, light_pos.y, light_pos.z, light.omni_range))
-				clouds_resource.point_lights_data.append(Vector4(light.light_color.r, light.light_color.g, light.light_color.b, round(light.light_color.a * light.light_energy * point_light_power_multiplier * 10.0) / 10.0))
+				new_point_data.append(Vector4(light_pos.x, light_pos.y, light_pos.z, light.omni_range))
+				new_point_data.append(Vector4(light.light_color.r, light.light_color.g, light.light_color.b, round(light.light_color.a * light.light_energy * point_light_power_multiplier * 10.0) / 10.0))
 		
 		
 		for i in range(tracked_point_effectors.size()):
 			if tracked_point_effectors[i] != null:
 				var node = tracked_point_effectors[i]
 				var node_pos = node.global_position
-				clouds_resource.point_effector_data.append(Vector4(node_pos.x, node_pos.y, node_pos.z, node.Radius))
-				clouds_resource.point_effector_data.append(Vector4(node.Power, 0.0, 0.0, 0.0))
+				new_effector_data.append(Vector4(node_pos.x, node_pos.y, node_pos.z, node.Radius))
+				new_effector_data.append(Vector4(node.Power, 0.0, 0.0, 0.0))
 		
 		
-		clouds_resource.lights_updated = true
+		# Driver-side copies, for _process's comparisons (main thread).
+		_dir_data_cache = new_dir_data.duplicate()
+		_point_data_cache = new_point_data.duplicate()
+		_effector_data_cache = new_effector_data.duplicate()
+
+		# Handed to the effect from the render thread: serialised with _render_callback.
+		RenderingServer.call_on_render_thread(_apply_lights_data.bind(new_dir_data, new_point_data, new_effector_data))
 	
 	_updating_settings = false
 

--- a/addons/SunshineClouds2/SunshineCloudsPostCompute.comp
+++ b/addons/SunshineClouds2/SunshineCloudsPostCompute.comp
@@ -22,8 +22,8 @@ layout(binding = 7) uniform LightsBuffer {
 };
 
 layout(binding = 8, std140) uniform SceneDataBlock {
-	SceneData data;
-	SceneData prev_data;
+	CameraData data;
+	CameraData prev_data;
 } scene_data_block;
 
 
@@ -321,8 +321,10 @@ void main() {
 		vec4 view = scene_data_block.data.inv_projection_matrix * vec4(depthUV*2.0-1.0,depth,1.0);
 		view.xyz /= view.w;
 		float linear_depth = length(view); //used to calculate depth based on the view angle, idk just works.
-		if (linear_depth >= scene_data_block.data.z_far){ 
-			linear_depth *= 100.0;
+		// Reverse-Z sky test (see main compute shader) - robust across the whole
+		// screen, unlike the marginal length(view) >= z_far comparison.
+		if (depth <= 0.0){
+			linear_depth = 1e9;
 		}
 		float density = clamp(currentAccumilation.a, 0.0, 1.0);
 


### PR DESCRIPTION
Camera matrices came from Godot's private SceneData UBO, which has no 4.7 layout. Pack our own instead, bound as CameraData at binding 17 and 8, plus absolute reprojection and a reverse-Z sky test. Camera fix by Old Sarriyn.

Driver rebuilt the light arrays in place, so under thread_model = 2 the render thread could catch them empty. Built in locals now, swapped via call_on_render_thread.